### PR TITLE
Chore/hanna/separation build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ yarn-error.log
 .metro-health-check*
 
 .env
+.env.*
 
 # react-native-config codegen
 ios/tmp.xcconfig

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -155,8 +155,7 @@ android {
     flavorDimensions "version"
     productFlavors {
         dev {
-          applicationIdSuffix ".dev"
-          manifestPlaceholders = [appName: "@string/app_name_dev"]
+          
         }
         prod {
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,5 +1,12 @@
 apply plugin: "com.android.application"
 apply plugin: "com.facebook.react"
+project.ext.envConfigFiles = [
+  devdebug: ".env.dev",
+  devrelease: ".env.dev",
+  proddebug: ".env.prod",
+  prodrelease: ".env.prod",
+]
+apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
 
 import com.android.build.OutputFile
 
@@ -142,6 +149,17 @@ android {
             shrinkResources true
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+        }
+    }
+
+    flavorDimensions "version"
+    productFlavors {
+        dev {
+          applicationIdSuffix ".dev"
+          manifestPlaceholders = [appName: "@string/app_name_dev"]
+        }
+        prod {
+
         }
     }
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <resources>
     <string name="app_name">All:chive</string>
-    <string name="app_name_dev">All:chive Dev</string>
     <string name="kakao_app_key">@string/ALLCHIVE_NATIVE_APP_KEY</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">All:chive</string>
+    <string name="app_name_dev">All:chive Dev</string>
     <string name="kakao_app_key">@string/ALLCHIVE_NATIVE_APP_KEY</string>
 </resources>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "private": true,
   "scripts": {
     "android": "react-native run-android",
+    "android-dev": "react-native run-android --variant=devdebug",
+    "android-prod": "react-native run-android --variant=proddebug",
+    "build-android-dev": "react-native run-android --variant=devrelease",
+    "build-android-prod": "react-native run-android --variant=prodrelease",
+    "make-aab-prod-r": "cd android && ./gradlew bundleProdRelease && cd ..",
     "ios": "react-native run-ios",
     "lint": "eslint .",
     "start": "react-native start",


### PR DESCRIPTION
앱 빌드 환경 분리 및 명령어 설정했습니다.
iOS 별도 설정이 필요합니다.
### 설명
- 기존의 .env 파일을 .env.dev와 .env.prod로 분리하고, 각 파일의 환경변수 명을 통일했습니다.
- build.gradle의 최상단에 devdebug, devrelease, proddebug, prodrelease를 선언하였고, react-native-config를 빌드레벨에서 사용할 수 있도록 설정하였습니다.
- 긴 명령어를 간단히 사용할 수 있도록 package.json에 (설정한 빌드환경으로 앱을 실행하는)스크립트 명령어를 추가했습니다.

**dev debug 실행**
`yarn android-dev`

**prod debug 실행**
`yarn android-prod`

**dev release실행 (apk 생성)**
`yarn build-android-dev`

**prod release 실행 (apk 생성)**
`yarn build-android-prod`

**prod release 실행 (aab 생성)**
`yarn make-aab-prod-r`

### Reference
https://hackmd.io/@workarticle/HJjsX8ini
https://sodevly.github.io/react-native-env/