### PR TITLE
Feat/emily/update login

### DIFF
--- a/src/apis/auth/OAuth.ts
+++ b/src/apis/auth/OAuth.ts
@@ -12,7 +12,9 @@ export const signUpUser = (
   profileImgUrl: string,
   nickname: string,
   categories: string[],
-  marketingAgreement: boolean
+  marketingAgreement: boolean,
+  name: string,
+  email: string
 ) => {
   return client.post(
     `/auth/oauth/register/${provider}`,
@@ -21,6 +23,8 @@ export const signUpUser = (
       nickname,
       categories,
       marketingAgreement,
+      name,
+      email,
     },
     {
       params: {

--- a/src/hooks/useUserInfo.tsx
+++ b/src/hooks/useUserInfo.tsx
@@ -1,0 +1,48 @@
+import { useRecoilState } from 'recoil'
+
+import { SignInResult } from '@/models/SignInResult'
+import {
+  EmailState,
+  IdTokenState,
+  NameState,
+  SignInTypeState,
+  ThirdpartyAccessTokenState,
+} from '@/state/signIn/UserState'
+
+/**
+ *
+ */
+const useUserInfo = () => {
+  const [idToken, setIdToken] = useRecoilState(IdTokenState)
+  const [thirdpartyAccessToken, setThirdpartyAccessToken] = useRecoilState(
+    ThirdpartyAccessTokenState
+  )
+  const [name, setName] = useRecoilState(NameState)
+  const [email, setEmail] = useRecoilState(EmailState)
+  const [signInType, setSignInType] = useRecoilState(SignInTypeState)
+
+  /**
+   * 유저 정보를 갱신합니다.
+   */
+  const updateUserInfo = ({ signInType, idToken, name, email, accessToken }: SignInResult) => {
+    setSignInType(signInType)
+    idToken && setIdToken(idToken)
+    name && setName(name)
+    email && setEmail(email)
+    accessToken && setThirdpartyAccessToken(accessToken)
+  }
+  /**
+   * 유저 정보를 제거합니다.
+   */
+  const clearUserInfo = () => {
+    setIdToken('')
+    setThirdpartyAccessToken('')
+    setName('')
+    setEmail('')
+    setSignInType(undefined)
+  }
+
+  return { idToken, thirdpartyAccessToken, name, email, signInType, clearUserInfo, updateUserInfo }
+}
+
+export default useUserInfo

--- a/src/models/SignInResult.ts
+++ b/src/models/SignInResult.ts
@@ -1,5 +1,10 @@
+import { SignInType } from './enums/SignInType'
+
 export interface SignInResult {
   canLogin: boolean
+  signInType: SignInType
   idToken?: string
   accessToken?: string
+  email?: string
+  name?: string
 }

--- a/src/navigations/RootStack.tsx
+++ b/src/navigations/RootStack.tsx
@@ -34,7 +34,6 @@ import SelectCategory from '@/screens/selectCategory/SelectCategory'
 import { TagManagement } from '@/screens/tagManagement/TagManagement'
 import { Upload } from '@/screens/upload/Upload'
 import { checkIsInstalled } from '@/services/localStorage/LocalStorage'
-import { SignInState } from '@/state/signIn/SignInState'
 import { colors } from '@/styles/colors'
 
 export type RootStackParamList = {
@@ -69,7 +68,7 @@ const Stack = createNativeStackNavigator<RootStackParamList>()
  * RootStack
  */
 export const RootStack = () => {
-  const [isSignIn, setIsSignIn] = useRecoilState(SignInState)
+  const [isSignIn, setIsSignIn] = useState(false)
   const [isInstalled, setIsInstalled] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
 

--- a/src/navigations/RootStack.tsx
+++ b/src/navigations/RootStack.tsx
@@ -6,12 +6,10 @@ import {
 } from '@react-navigation/native-stack'
 import { SafeAreaView } from 'react-native'
 import SplashScreen from 'react-native-splash-screen'
-import { useRecoilState } from 'recoil'
 
 import { canAuthSignIn } from '@/apis/auth/Auth'
 import { ContentType } from '@/models/enums/ContentType'
 import { ReportType } from '@/models/enums/ReportType'
-import { SignInType } from '@/models/enums/SignInType'
 import { BottomTab, BottomTabNavigationParams } from '@/navigations/bottomTab/BottomTab'
 import AddProfile from '@/screens/addProfile/AddProfile'
 import { Agreement } from '@/screens/agreement/Agreement'
@@ -39,9 +37,9 @@ import { colors } from '@/styles/colors'
 export type RootStackParamList = {
   OnBoarding1: undefined
   OnBoarding2: undefined
-  Agreement: { type: SignInType }
-  SelectCategory: { type: SignInType; marketingAgreement: boolean }
-  AddProfile: { type: SignInType; categories: string[]; marketingAgreement: boolean }
+  Agreement: undefined
+  SelectCategory: { marketingAgreement: boolean }
+  AddProfile: { categories: string[]; marketingAgreement: boolean }
   BottomTab: BottomTabNavigationParams
   Login: undefined
   ContentList: { id: number; title: string }
@@ -116,21 +114,18 @@ export const RootStack = () => {
         <Stack.Screen
           name="Agreement"
           component={Agreement}
-          initialParams={{ type: SignInType.Kakao }}
           options={{ gestureEnabled: false }}
         />
         <Stack.Screen
           name="SelectCategory"
           component={SelectCategory}
-          initialParams={{ type: SignInType.Kakao }}
           options={{ gestureEnabled: false }}
         />
         <Stack.Screen
           name="AddProfile"
           component={AddProfile}
           initialParams={{
-            type: SignInType.Kakao,
-            categories: ['FOOD'],
+            categories: [],
           }}
           options={{ gestureEnabled: false }}
         />

--- a/src/screens/addProfile/AddProfile.tsx
+++ b/src/screens/addProfile/AddProfile.tsx
@@ -16,7 +16,6 @@ import { RootStackParamList } from '@/navigations/RootStack'
 import { signUp } from '@/services/SignInService'
 import { checkNickname } from '@/services/StringChecker'
 import { setIsInstalled } from '@/services/localStorage/LocalStorage'
-import { SignInState } from '@/state/signIn/SignInState'
 import { IdTokenState, ThirdpartyAccessTokenState } from '@/state/signIn/UserState'
 import { colors } from '@/styles/colors'
 
@@ -38,7 +37,6 @@ interface AddProfileProps {
  * AddProfile
  */
 const AddProfile = ({ route }: AddProfileProps) => {
-  const setIsSignIn = useSetRecoilState(SignInState)
   const [nickname, setNickname] = useState('')
   const [isNicknameValid, setIsNicknameValid] = useState(false)
   const [isNicknameDuplicate, setIsNicknameDuplicate] = useState(false)
@@ -62,7 +60,6 @@ const AddProfile = ({ route }: AddProfileProps) => {
 
     if (isSucess) {
       setIsInstalled(true)
-      setIsSignIn(true)
       navigation.navigate('BottomTab', { screen: 'Home' })
     }
   }

--- a/src/screens/agreement/Agreement.tsx
+++ b/src/screens/agreement/Agreement.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 
-import { RouteProp, useNavigation } from '@react-navigation/native'
+import { useNavigation } from '@react-navigation/native'
 
 import CheckIcon from '@/assets/icons/check-yellow.svg'
 import RightArrowIcon from '@/assets/icons/right-arrow.svg'
@@ -10,7 +10,6 @@ import DefaultScrollContainer from '@/components/containers/defaultScrollContain
 import { marketing, privacy, terms } from '@/const/Const'
 import i18n from '@/locales'
 import { MainNavigationProp } from '@/navigations/MainNavigator'
-import { RootStackParamList } from '@/navigations/RootStack'
 import { openInappBrowser } from '@/services/InappBrowser'
 import { colors } from '@/styles/colors'
 
@@ -26,14 +25,10 @@ import {
   Title,
 } from './Agreement.style'
 
-interface AgreementProps {
-  route: RouteProp<RootStackParamList, 'Agreement'>
-}
-
 /**
  * 약관 동의 화면
  */
-export const Agreement = ({ route }: AgreementProps) => {
+export const Agreement = () => {
   const navigation = useNavigation<MainNavigationProp>()
 
   const [allCheck, setAllCheck] = useState(false)
@@ -96,7 +91,6 @@ export const Agreement = ({ route }: AgreementProps) => {
    */
   const handleComplete = () => {
     navigation.navigate('SelectCategory', {
-      type: route.params.type,
       marketingAgreement: agreements.marketing,
     })
   }

--- a/src/screens/login/Login.tsx
+++ b/src/screens/login/Login.tsx
@@ -15,7 +15,6 @@ import { SignInType } from '@/models/enums/SignInType'
 import { MainNavigationProp } from '@/navigations/MainNavigator'
 import { signInWith } from '@/services/SignInService'
 import { setIsInstalled } from '@/services/localStorage/LocalStorage'
-import { SignInState } from '@/state/signIn/SignInState'
 import { IdTokenState, ThirdpartyAccessTokenState } from '@/state/signIn/UserState'
 
 import { Button, Container, LoginButtons, Logo, SubLogo, Title } from './Login.style'
@@ -28,7 +27,6 @@ export const Login = () => {
 
   const setIdTokenState = useSetRecoilState(IdTokenState)
   const setThirdpartyAccessTokenState = useSetRecoilState(ThirdpartyAccessTokenState)
-  const IsSignInState = useSetRecoilState(SignInState)
 
   const [type, setType] = useState<SignInType>(SignInType.Kakao)
   const [enabled, setEnabled] = useState(false)
@@ -45,7 +43,6 @@ export const Login = () => {
         return
       }
       if (data.canLogin) {
-        IsSignInState(true)
         setIsInstalled(true)
         navigation.navigate('BottomTab', { screen: 'Home' })
       } else if (!data.canLogin && data.idToken) {

--- a/src/screens/login/Login.tsx
+++ b/src/screens/login/Login.tsx
@@ -1,21 +1,20 @@
-import React, { useState } from 'react'
+import React from 'react'
 
 import { useNavigation } from '@react-navigation/native'
 import { Platform } from 'react-native'
-import { useQuery } from 'react-query'
-import { useSetRecoilState } from 'recoil'
+import { useMutation } from 'react-query'
 
 import { logo } from '@/assets'
 import AppleLogo from '@/assets/login/apple.svg'
 import KakaoLogo from '@/assets/login/kakao.svg'
 import DefaultContainer from '@/components/containers/defaultContainer/DefaultContainer'
 import { Loading } from '@/components/loading/Loading'
+import useUserInfo from '@/hooks/useUserInfo'
 import i18n from '@/locales'
 import { SignInType } from '@/models/enums/SignInType'
 import { MainNavigationProp } from '@/navigations/MainNavigator'
 import { signInWith } from '@/services/SignInService'
 import { setIsInstalled } from '@/services/localStorage/LocalStorage'
-import { IdTokenState, ThirdpartyAccessTokenState } from '@/state/signIn/UserState'
 
 import { Button, Container, LoginButtons, Logo, SubLogo, Title } from './Login.style'
 
@@ -24,32 +23,27 @@ import { Button, Container, LoginButtons, Logo, SubLogo, Title } from './Login.s
  */
 export const Login = () => {
   const navigation = useNavigation<MainNavigationProp>()
+  const { updateUserInfo } = useUserInfo()
 
-  const setIdTokenState = useSetRecoilState(IdTokenState)
-  const setThirdpartyAccessTokenState = useSetRecoilState(ThirdpartyAccessTokenState)
-
-  const [type, setType] = useState<SignInType>(SignInType.Kakao)
-  const [enabled, setEnabled] = useState(false)
-
-  const { isLoading } = useQuery(['signIn', type], () => signInWith(type), {
-    enabled: enabled,
+  const { mutate: signInMutate, isLoading } = useMutation(signInWith, {
     /**
      * 로그인 성공 시
      */
     onSuccess: (data) => {
-      setEnabled(false)
+      updateUserInfo(data)
 
-      if (!data) {
-        return
-      }
       if (data.canLogin) {
         setIsInstalled(true)
         navigation.navigate('BottomTab', { screen: 'Home' })
       } else if (!data.canLogin && data.idToken) {
-        setIdTokenState(data.idToken)
-        setThirdpartyAccessTokenState(data.accessToken ?? '')
-        navigation.navigate('Agreement', { type })
+        navigation.navigate('Agreement')
       }
+    },
+    /**
+     *
+     */
+    onError: () => {
+      //ignore
     },
     retry: 0,
   })
@@ -57,7 +51,6 @@ export const Login = () => {
   return (
     <>
       {isLoading && <Loading />}
-
       <DefaultContainer>
         <Container>
           <SubLogo>always, all, archive</SubLogo>
@@ -68,8 +61,7 @@ export const Login = () => {
               ios: (
                 <Button
                   onPress={() => {
-                    setEnabled(true)
-                    setType(SignInType.Apple)
+                    signInMutate(SignInType.Apple)
                   }}
                 >
                   <AppleLogo />
@@ -78,8 +70,7 @@ export const Login = () => {
             })}
             <Button
               onPress={() => {
-                setEnabled(true)
-                setType(SignInType.Kakao)
+                signInMutate(SignInType.Kakao)
               }}
             >
               <KakaoLogo />

--- a/src/screens/myAccount/MyAccount.tsx
+++ b/src/screens/myAccount/MyAccount.tsx
@@ -18,6 +18,7 @@ import { LeftButtonHeader } from '@/components/headers/leftButtonHeader/LeftButt
 import Indicator from '@/components/indicator/Indicator'
 import { Loading } from '@/components/loading/Loading'
 import NicknameEditModal from '@/components/modal/nicknameEditModal/NicknameEditModal'
+import useUserInfo from '@/hooks/useUserInfo'
 import i18n from '@/locales'
 import { DefalutMenus, DefaultMenuType } from '@/models/enums/ActionSheetType'
 import { SignInType } from '@/models/enums/SignInType'
@@ -56,6 +57,7 @@ export const MyAccount = () => {
   const [nickname, setNickname] = useState('')
   const [isNicknameEditModalVisible, setIsNicknameEditModalVisible] = useState(false)
   const [errorDialogVisible, setErrorDialogVisible] = useState(false)
+  const { clearUserInfo } = useUserInfo()
 
   const { data: userInfoData, isLoading: isProfileLoading } = useQuery(
     ['getUserInfo'],
@@ -110,7 +112,9 @@ export const MyAccount = () => {
      * 회원탈퇴 성공 시 로그인 화면으로 넘어갑니다.
      */
     onSuccess: () => {
-      navigation.navigate('Login')
+      queryClient.clear()
+      clearUserInfo()
+      navigation.reset({ routes: [{ name: 'Login' }] })
     },
   })
 

--- a/src/screens/myAccount/MyAccount.tsx
+++ b/src/screens/myAccount/MyAccount.tsx
@@ -112,9 +112,9 @@ export const MyAccount = () => {
      * 회원탈퇴 성공 시 로그인 화면으로 넘어갑니다.
      */
     onSuccess: () => {
-      queryClient.clear()
       clearUserInfo()
       navigation.reset({ routes: [{ name: 'Login' }] })
+      queryClient.clear()
     },
   })
 

--- a/src/screens/mypage/Mypage.tsx
+++ b/src/screens/mypage/Mypage.tsx
@@ -16,6 +16,7 @@ import DefaultContainer from '@/components/containers/defaultContainer/DefaultCo
 import { InformationErrorDialog } from '@/components/dialogs/errorDialog/InformationErrorDialog/InformationErrorDialog'
 import { Loading } from '@/components/loading/Loading'
 import { community, customerService, openSourceLicense, privacy, terms } from '@/const/Const'
+import useUserInfo from '@/hooks/useUserInfo'
 import i18n from '@/locales'
 import { MainNavigationProp } from '@/navigations/MainNavigator'
 import { colors } from '@/styles/colors'
@@ -45,6 +46,7 @@ export const Mypage = () => {
 
   const [isProfileImageError, setIsProfileImageError] = useState(false)
   const [errorDialogVisible, setErrorDialogVisible] = useState(false)
+  const { clearUserInfo } = useUserInfo()
 
   const { data: profileData, isLoading: isProfileLoading } = useQuery(['getUser'], () => getUser())
 
@@ -54,7 +56,8 @@ export const Mypage = () => {
      */
     onSuccess: () => {
       queryClient.clear()
-      navigation.navigate('Login')
+      clearUserInfo()
+      navigation.reset({ routes: [{ name: 'Login' }] })
     },
     /**
      *

--- a/src/screens/mypage/Mypage.tsx
+++ b/src/screens/mypage/Mypage.tsx
@@ -55,9 +55,9 @@ export const Mypage = () => {
      *
      */
     onSuccess: () => {
-      queryClient.clear()
       clearUserInfo()
       navigation.reset({ routes: [{ name: 'Login' }] })
+      queryClient.clear()
     },
     /**
      *

--- a/src/screens/selectCategory/SelectCategory.tsx
+++ b/src/screens/selectCategory/SelectCategory.tsx
@@ -46,7 +46,6 @@ const SelectCategory = ({ route }: SelectCategoryProps) => {
    */
   const handleSubmitCategory = () => {
     navigation.navigate('AddProfile', {
-      type: route.params.type,
       categories: selectedCategory,
       marketingAgreement: route.params.marketingAgreement,
     })

--- a/src/services/SignInService.ts
+++ b/src/services/SignInService.ts
@@ -22,22 +22,24 @@ export const signInWith = (type: SignInType) => {
 /**
  * signInWithApple
  */
-const signInWithApple = async (): Promise<SignInResult | undefined> => {
-  try {
-    const { user, identityToken } = await appleAuth.performRequest({
-      requestedOperation: appleAuth.Operation.LOGIN,
-      requestedScopes: [appleAuth.Scope.FULL_NAME, appleAuth.Scope.EMAIL],
-    })
+const signInWithApple = async (): Promise<SignInResult> => {
+  const { user, identityToken, fullName, email } = await appleAuth.performRequest({
+    requestedOperation: appleAuth.Operation.LOGIN,
+    requestedScopes: [appleAuth.Scope.FULL_NAME, appleAuth.Scope.EMAIL],
+  })
 
-    const credentialState = await appleAuth.getCredentialStateForUser(user)
+  const credentialState = await appleAuth.getCredentialStateForUser(user)
 
-    if (credentialState === appleAuth.State.AUTHORIZED && identityToken) {
-      return getIsUser(SignInType.Apple, identityToken, '')
-    }
-
-    return
-  } catch (err) {
-    return
+  if (credentialState === appleAuth.State.AUTHORIZED && identityToken) {
+    return getIsUser(
+      SignInType.Apple,
+      identityToken,
+      '',
+      `${fullName?.familyName ?? ''}${fullName?.givenName ?? ''}`,
+      email ?? ''
+    )
+  } else {
+    throw new Error('애플로그인 권한 또는 토큰이 없습니다.')
   }
 }
 
@@ -60,49 +62,38 @@ export const getAppleAuthCode = async () => {
 /**
  * signInWithKakao
  */
-const signInWithKakao = async (): Promise<SignInResult | undefined> => {
-  try {
-    const data = await login()
-
-    if (data) {
-      return getIsUser(SignInType.Kakao, data['idToken'], data['accessToken'])
-    }
-
-    return
-  } catch (err) {
-    //ignore
-    return
-  }
+const signInWithKakao = async (): Promise<SignInResult> => {
+  const data = await login()
+  return getIsUser(SignInType.Kakao, data['idToken'], data['accessToken'])
 }
 
 /**
  * 유저인지 확인합니다.
  */
 const getIsUser = async (
-  type: string,
+  type: SignInType,
   idToken: string,
-  accessToken: string
-): Promise<SignInResult | undefined> => {
-  try {
-    const response = await postIdTokenLogin(type, idToken)
+  accessToken: string,
+  name?: string,
+  email?: string
+): Promise<SignInResult> => {
+  const response = await postIdTokenLogin(type, idToken)
 
-    if (!response?.data?.data) {
-      return
-    } else if (!response.data.data['canLogin']) {
-      return {
-        canLogin: false,
-        idToken,
-        accessToken,
-      }
-    } else {
-      saveTokens(response.data.data['refreshToken'], response.data.data['accessToken'])
-      return {
-        canLogin: true,
-      }
+  if (!response.data.data['canLogin']) {
+    return {
+      canLogin: false,
+      signInType: type,
+      idToken,
+      accessToken,
+      name,
+      email,
     }
-  } catch (err) {
-    //ignore
-    return
+  } else {
+    saveTokens(response.data.data['refreshToken'], response.data.data['accessToken'])
+    return {
+      canLogin: true,
+      signInType: type,
+    }
   }
 }
 
@@ -116,35 +107,29 @@ export const signUp = async (
   profileImgUrl: string,
   nickname: string,
   categories: string[],
-  marketingAgreement: boolean
+  marketingAgreement: boolean,
+  name: string,
+  email: string
 ) => {
-  try {
-    const response = await signUpUser(
-      provider,
-      idToken,
-      accessToken,
-      profileImgUrl,
-      nickname,
-      categories,
-      marketingAgreement
-    )
+  const response = await signUpUser(
+    provider,
+    idToken,
+    accessToken,
+    profileImgUrl,
+    nickname,
+    categories,
+    marketingAgreement,
+    name,
+    email
+  )
 
-    if (!response?.data?.data) {
-      return false
-    } else {
-      saveTokens(response.data.data['refreshToken'], response.data.data['accessToken'])
-      return true
-    }
-  } catch (err) {
-    //ignore
-    return false
-  }
+  saveTokens(response.data.data['refreshToken'], response.data.data['accessToken'])
 }
 
 /**
  * saveTokens
  */
-export const saveTokens = (refreshToken: string, accessToken: string) => {
+const saveTokens = (refreshToken: string, accessToken: string) => {
   setRefreshToken(refreshToken)
   setAccessToken(accessToken)
 }

--- a/src/state/signIn/SignInState.ts
+++ b/src/state/signIn/SignInState.ts
@@ -1,6 +1,0 @@
-import { atom } from 'recoil'
-
-export const SignInState = atom<boolean>({
-  key: 'signInState',
-  default: false,
-})

--- a/src/state/signIn/UserState.ts
+++ b/src/state/signIn/UserState.ts
@@ -1,5 +1,7 @@
 import { atom } from 'recoil'
 
+import { SignInType } from '@/models/enums/SignInType'
+
 export const IdTokenState = atom<string>({
   key: 'idTokenState',
   default: '',
@@ -8,4 +10,19 @@ export const IdTokenState = atom<string>({
 export const ThirdpartyAccessTokenState = atom<string>({
   key: 'ThirdpartyAccessTokenState',
   default: '',
+})
+
+export const NameState = atom<string>({
+  key: 'nameState',
+  default: '',
+})
+
+export const EmailState = atom<string>({
+  key: 'emailState',
+  default: '',
+})
+
+export const SignInTypeState = atom<SignInType | undefined>({
+  key: 'SignInTypeState',
+  default: undefined,
 })


### PR DESCRIPTION
로그인 리팩토링 및 애플에서 이름, 이메일 전달하도록 변경
* 로그인, 회원가입 시 mutate 사용하도록 변경
* 회원가입 확인 버튼 클릭 시 로딩 인디케이터 보이도록 변경
* UserInfo 관리하는 훅 추가
* 로그아웃, 회원 탈퇴시 UserInfo 초기화
* 로그아웃, 회원 탈퇴 시 navigation 초기화
* 애플 회원가입시 이름, 이메일 전달하도록 변경